### PR TITLE
Fix: encode reserved keywords

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -13,6 +13,7 @@ to BambooHR API calls defined at http://www.bamboohr.com/api/documentation/.
 import datetime
 import requests
 import utils
+from utils import make_field_xml
 
 # Python 3 basestring compatibility:
 try:
@@ -176,7 +177,7 @@ class PyBambooHR(object):
             if not self.employee_fields.get(key):
                 raise UserWarning("You passed in an invalid field")
             else:
-                xml_fields += '\t<field id="{0}">{1}</field>\n'.format(key, employee[key])
+                xml_fields += make_field_xml(key, employee[key], pre='\t', post='\n')
 
         # Really cheesy way to build XML... this should probably be replaced at some point.
         xml = "<employee>\n{}</employee>".format(xml_fields)
@@ -191,7 +192,7 @@ class PyBambooHR(object):
         """
         xml_fields = ''
         for k, v in row.iteritems():
-            xml_fields += '\t<field id="{0}">{1}</field>\n'.format(k, v)
+            xml_fields += make_field_xml(k, v, pre='\t', post='\n')
 
         xml = "<row>\n{}</row>".format(xml_fields)
         return xml
@@ -204,7 +205,7 @@ class PyBambooHR(object):
         """
         xml_fields = ''
         for field in fields:
-            xml_fields += '\t\t<field id="{0}" />\n'.format(field)
+            xml_fields += make_field_xml(field, None, pre='\t\t', post='\n')
 
         # Really cheesy way to build XML... this should probably be replaced at some point.
         xml = '''<report output="{0}">\n\t<title>{1}</title>\n\t<fields>\n{2}\t</fields>\n</report>'''.format(report_format, title, xml_fields)

--- a/PyBambooHR/utils.py
+++ b/PyBambooHR/utils.py
@@ -50,6 +50,17 @@ def underscore_keys(data):
 
 _date_regex = re.compile(r"^\d{4}-\d{2}-\d{2}")
 
+
+def make_field_xml(id, value=None, pre='', post=''):
+    id = escape(str(id))
+    if value:
+        value = escape(str(value))
+        tag = '<field id="{}">{}</field>'.format(id, value)
+    else:
+        tag = '<field id="{}" />'.format(id)
+    return '{0}{1}{2}'.format(pre, tag, post)
+
+
 def resolve_date_argument(arg):
     if isinstance(arg, (datetime.datetime, datetime.date)):
         return arg.strftime('%Y-%m-%d')
@@ -130,3 +141,19 @@ def _extract(xml_obj, first_key, second_key):
 
 def _parse_xml(input):
     return xmltodict.parse(input)
+
+
+XML_ESCAPES = (
+    ('<', '&lt;'),
+    ('>', '&gt;'),
+    ('&', '&amp;'),
+    ("'", '&apos;'),
+    ('"', '&quot;'),
+)
+
+
+def escape(to_escape):
+    """Returns the given string with XML reserved characters encoded."""
+    for char, repl in XML_ESCAPES:
+        to_escape = to_escape.replace(char, repl)
+    return to_escape

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -74,6 +74,17 @@ class test_misc(unittest.TestCase):
         self.assertEqual('321 Value A', rows[1]['field'][0]['#text'])
         self.assertEqual('321 Value B', rows[1]['field'][1]['#text'])
 
+    def test_make_field_xml(self):
+        xml = utils.make_field_xml('123', 'T&C')
+        self.assertEqual('<field id="123">T&amp;C</field>', xml)
+
+        xml = utils.make_field_xml('123', 'T&C', pre='\t', post='\n')
+        self.assertEqual('\t<field id="123">T&amp;C</field>\n', xml)
+
+        xml = utils.make_field_xml('123', None, pre='\t', post='\n')
+        self.assertEqual('\t<field id="123" />\n', xml)
+        pass
+
     def test__format_row_xml(self):
         row = {'f1': 'v1', 'f2': 'v2'}
         xml = self.bamboo._format_row_xml(row)
@@ -88,7 +99,7 @@ class test_misc(unittest.TestCase):
                      <field id="customFieldB">123 Value B</field>
                    </row>
                    <row id="999" employeeId="321">
-                     <field id="customFieldA">321 Value A</field>
+                     <field id="customFieldA">321 &amp; Value A</field>
                    </row>
                  </table>"""
         table = {'123': [{
@@ -96,7 +107,7 @@ class test_misc(unittest.TestCase):
                          'customFieldB': '123 Value B',
                          'row_id': '321'}],
                  '321': [{
-                         'customFieldA': '321 Value A',
+                         'customFieldA': '321 & Value A',
                          'row_id': '999'}]}
         self.assertEqual(table, utils.transform_tabular_data(xml))
 


### PR DESCRIPTION
When making XML payload to send to BambooHR, we need to encode the XML
data, e.g. '&' need to be changed to '&amp;'.
Ref #17 
Characters that will be included listed in [W3C XML spec](http://www.w3.org/TR/REC-xml/#sec-predefined-ent)