### PR TITLE
make utils import a local import

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -12,8 +12,8 @@ to BambooHR API calls defined at http://www.bamboohr.com/api/documentation/.
 
 import datetime
 import requests
-import utils
-from utils import make_field_xml
+from . import utils
+from .utils import make_field_xml
 
 # Python 3 basestring compatibility:
 try:


### PR DESCRIPTION
The current import of utils causes a `ImportError`, ideally it should be import locally from local package.

This pull request will import `utils` from local package.