### PR TITLE
adding support for effective dates

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -34,7 +34,7 @@ class PyBambooHR(object):
     and an optional datatype argument (defaults to JSON). This class implements
     methods for basic CRUD operations for employees and more.
     """
-    def __init__(self, subdomain='', api_key='', datatype='JSON', underscore_keys=False):
+    def __init__(self, subdomain='', api_key='', onlyCurrent=True, datatype='JSON', underscore_keys=False):
         """
         Using the subdomain, __init__ initializes the base_url for our API calls.
         This method also sets up some headers for our HTTP requests as well as our authentication (API key).
@@ -69,6 +69,9 @@ class PyBambooHR(object):
 
         # Some people will want to use underscore keys for employee data...
         self.underscore_keys = underscore_keys
+
+        # Ask BambooHR for information that is scheduled in the future
+        self.onlyCurrent = onlyCurrent
 
         # We are focusing on JSON for now.
         if self.datatype == 'XML':
@@ -294,6 +297,11 @@ class PyBambooHR(object):
             'fields': ",".join(get_fields)
         }
 
+        if self.onlyCurrent == False:
+            payload.update({
+                'onlyCurrent': 'false'
+            })
+
         url = self.base_url + "employees/{0}".format(employee_id)
         r = requests.get(url, headers=self.headers, params=payload, auth=(self.api_key, ''))
         r.raise_for_status()
@@ -401,7 +409,7 @@ class PyBambooHR(object):
             raise UserWarning("You requested an invalid report type. Valid values are: {0}".format(','.join([k for k in self.report_formats])))
 
         filter_duplicates = 'yes' if filter_duplicates else 'no'
-        url = self.base_url + "reports/{0}?format={1}&fd={2}".format(report_id, report_format, filter_duplicates)
+        url = self.base_url + "reports/{0}?format={1}&fd={2}&onlyCurrent={3}".format(report_id, report_format, filter_duplicates, self.onlyCurrent)
         r = requests.get(url, headers=self.headers, auth=(self.api_key, ''))
         r.raise_for_status()
 

--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ for employee in result['employees']:
 result = bamboo.request_company_report(1, format='pdf', output_file='/tmp/report.pdf', filter_duplicates=True)
 
 ```
+Getting information that is scheduled in the future
+```python
+from PyBambooHR import PyBambooHR
+
+bamboo = PyBambooHR(subdomain='yoursub', api_key='yourapikeyhere', onlyCurrent=False)
+
+```
+BambooHR has effective dates for when promotions are scheduled to happen or when new hires are going to join the organization. In order to see these events before they happen using the BambooHR API set `onlyCurrent` to `False`. As a note, this only works for pulling reports and getting employee information. This does not work on getting the employee directory.


### PR DESCRIPTION
My organization's onboarding workflows depend on pulling information about new hires prior to their first day.  BambooHR recently implemented "Effective Dates" which will allow changes (promotions, compensation changes, etc.) to be scheduled to happen.  BambooHR added a parameter `onlyCurrent` which will allow you to see scheduled changes via the API prior to the changes taking place.

Example - getting a future employee's department prior to their start date: 
```bash
curl -i -u "API_KEY:x" "https://api.bamboohr.com/api/gateway.php/<organization>/v1/employees/<id>?fields=department"
HTTP/1.1 200 OK
Server: nginx
Content-Type: text/xml; charset=UTF-8
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
Cache-Control: no-cache
Date: Mon, 13 Nov 2017 00:35:45 GMT
Strict-Transport-Security: max-age=604800; includeSubdomains;
Vary: Authorization,User-Agent
X-Content-Type-Options: nosniff

<?xml version="1.0"?>
<employee id="<id>">
 <field id="department"></field>
</employee>
```

Using `onlyCurrent=false`
```bash
curl -i -u "API_KEY:x" "https://api.bamboohr.com/api/gateway.php/<organization>/v1/employees/<id>?fields=department&onlyCurrent=false"
HTTP/1.1 200 OK
Server: nginx
Content-Type: text/xml; charset=UTF-8
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
Cache-Control: no-cache
Date: Mon, 13 Nov 2017 00:35:45 GMT
Strict-Transport-Security: max-age=604800; includeSubdomains;
Vary: Authorization,User-Agent
X-Content-Type-Options: nosniff

<?xml version="1.0"?>
<employee id="<id>">
 <field id="department">Merchant Activation</field>
</employee>
```

This functionality is implemented by adding `onlyCurrent` to the initial call of the PyBambooHR class.
```python
bamboo = PyBambooHR(subdomain='yoursub', api_key='yourapikeyhere', onlyCurrent=False)
```
When `onlyCurrent` is not specified in the initial call it is assumed to be `True`, this way the library retains the current functionality.  