### PR TITLE
Add try except for basestring

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -22,6 +22,13 @@ try:
 except NameError:
     # unicode is undefined: We are running Python 3
     unicode = str
+
+    # basestring is undefined: We are running Python 3
+    try:
+        basestring
+    except NameError:
+        basestring = str
+
     basestring = (str, bytes)
 else:
     # unicode is defined: We are running Python 2

--- a/PyBambooHR/utils.py
+++ b/PyBambooHR/utils.py
@@ -62,6 +62,12 @@ def make_field_xml(id, value=None, pre='', post=''):
 
 
 def resolve_date_argument(arg):
+    # basestring is undefined: We are running Python 3
+    try:
+        basestring
+    except NameError:
+        basestring = str
+
     if isinstance(arg, (datetime.datetime, datetime.date)):
         return arg.strftime('%Y-%m-%d')
     elif isinstance(arg, basestring) and _date_regex.match(arg):


### PR DESCRIPTION
Hi, I ran into an issue trying to get info if an employee is out or not. I was using Python3, but **basestring** exists only in Python2. So I just added exception handling for that case. Worked fine for me afterwards. Would be cool if you could merge this. Thanks!