### PR TITLE
Special characters support

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -182,7 +182,7 @@ class PyBambooHR(object):
                 xml_fields += make_field_xml(key, employee[key], pre='\t', post='\n')
 
         # Really cheesy way to build XML... this should probably be replaced at some point.
-        xml = "<employee>\n{}</employee>".format(xml_fields)
+        xml = "<employee>\n%s</employee>" % xml_fields
         return xml
 
     def _format_row_xml(self, row):
@@ -196,7 +196,7 @@ class PyBambooHR(object):
         for k, v in row.iteritems():
             xml_fields += make_field_xml(k, v, pre='\t', post='\n')
 
-        xml = "<row>\n{}</row>".format(xml_fields)
+        xml = "<row>\n%s</row>" % xml_fields
         return xml
 
     def _format_report_xml(self, fields, title='My Custom Report', report_format='pdf'):
@@ -210,7 +210,7 @@ class PyBambooHR(object):
             xml_fields += make_field_xml(field, None, pre='\t\t', post='\n')
 
         # Really cheesy way to build XML... this should probably be replaced at some point.
-        xml = '''<report output="{0}">\n\t<title>{1}</title>\n\t<fields>\n{2}\t</fields>\n</report>'''.format(report_format, title, xml_fields)
+        xml = '''<report output="%s">\n\t<title>%s</title>\n\t<fields>\n%s\t</fields>\n</report>''' % (report_format, title, xml_fields)
         return xml
 
     def add_employee(self, employee):

--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -183,7 +183,7 @@ class PyBambooHR(object):
 
         # Really cheesy way to build XML... this should probably be replaced at some point.
         xml = "<employee>\n%s</employee>" % xml_fields
-        return xml
+        return xml.encode('utf-8')
 
     def _format_row_xml(self, row):
         """
@@ -197,7 +197,7 @@ class PyBambooHR(object):
             xml_fields += make_field_xml(k, v, pre='\t', post='\n')
 
         xml = "<row>\n%s</row>" % xml_fields
-        return xml
+        return xml.encode('utf-8')
 
     def _format_report_xml(self, fields, title='My Custom Report', report_format='pdf'):
         """
@@ -211,7 +211,7 @@ class PyBambooHR(object):
 
         # Really cheesy way to build XML... this should probably be replaced at some point.
         xml = '''<report output="%s">\n\t<title>%s</title>\n\t<fields>\n%s\t</fields>\n</report>''' % (report_format, title, xml_fields)
-        return xml
+        return xml.encode('utf-8')
 
     def add_employee(self, employee):
         """

--- a/PyBambooHR/utils.py
+++ b/PyBambooHR/utils.py
@@ -6,6 +6,13 @@ import datetime
 import re
 import xmltodict
 
+# keep python 2 - 3 compatibility
+try:
+    unicode
+except:
+    unicode = str
+
+
 def camelcase_keys(data):
     """
     Converts all the keys in a dict to camelcase. It works recursively to convert any nested dicts as well.
@@ -54,11 +61,11 @@ _date_regex = re.compile(r"^\d{4}-\d{2}-\d{2}")
 def make_field_xml(id, value=None, pre='', post=''):
     id = escape(str(id))
     if value:
-        value = escape(str(value))
-        tag = '<field id="{}">{}</field>'.format(id, value)
+        value = escape(unicode(value))
+        tag = '<field id="%s">%s</field>' % (id, value)
     else:
-        tag = '<field id="{}" />'.format(id)
-    return '{0}{1}{2}'.format(pre, tag, post)
+        tag = '<field id="%s" />' % id
+    return '%s%s%s' % (pre, tag, post)
 
 
 def resolve_date_argument(arg):

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if os.path.exists('README.txt'):
 
 setup(
     name='PyBambooHR',
-    version='0.7.0',
+    version='0.7.1',
     url='http://github.com/smeggingsmegger/PyBambooHR',
     license='MIT',
     author='Scott Blevins',

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -187,6 +187,13 @@ class test_employees(unittest.TestCase):
         result = self.bamboo.add_employee(employee)
         self.assertEqual(result['id'], '333')
 
+        employee = {
+            'firstName': u'Test',
+            'lastName': u'Pêrsón'
+        }
+        result = self.bamboo.add_employee(employee)
+        self.assertEqual(result['id'], '333')
+
     @httpretty.activate
     def test_add_employee_failure(self):
         httpretty.register_uri(httpretty.POST, "https://api.bamboohr.com/api/gateway.php/test/v1/employees/",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -83,7 +83,9 @@ class test_misc(unittest.TestCase):
 
         xml = utils.make_field_xml('123', None, pre='\t', post='\n')
         self.assertEqual('\t<field id="123" />\n', xml)
-        pass
+
+        xml = utils.make_field_xml('123', u'Úñíçôdé')
+        self.assertEqual(u'<field id="123">Úñíçôdé</field>', xml)
 
     def test__format_row_xml(self):
         row = {'f1': 'v1', 'f2': 'v2'}


### PR DESCRIPTION
Current version presents problems when special characters are used as input values. This happens mainly due to the use of `formats` and lack of encoding on XMLs.

This changes were also tested against the real BambooHR API.