### PR TITLE
fix get_employee with custom field

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -314,7 +314,7 @@ class PyBambooHR(object):
 
         if field_list:
             for f in field_list:
-                if not self.employee_fields.get(f):
+                if not f.startswith('custom') and not self.employee_fields.get(f):
                     raise UserWarning("You passed in an invalid field")
                 else:
                     get_fields.append(f)

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -154,6 +154,23 @@ class test_employees(unittest.TestCase):
         self.assertEquals(employee['work_phone'], '555-555-5555')
 
     @httpretty.activate
+    def test_get_employee_custom_fields(self):
+        # Request custom fields
+        httpretty.register_uri(httpretty.GET, "https://api.bamboohr.com/api/gateway.php/test/v1/employees/123",
+                               body='{"customField": "custom value", "id": "123"}',
+                               content_type="application/json")
+
+        employee = self.bamboo.get_employee(123, ['customCustomField', ])
+        self.assertIsNotNone(employee)
+        self.assertEquals(employee['customField'], 'custom value')
+        self.assertEquals(employee['id'], '123')
+
+        employee = self.bamboo_u.get_employee(123, ['customCustomField', ])
+        self.assertIsNotNone(employee)
+        self.assertEquals(employee['custom_field'], 'custom value')
+        self.assertEquals(employee['id'], '123')
+
+    @httpretty.activate
     def test_get_employee_all_fields(self):
         # Request all fields
         # NOTE: We are mocking this so we aren't getting all fields- we are just adding city.
@@ -308,4 +325,3 @@ class test_employees(unittest.TestCase):
         result = self.bamboo.update_row('customTable', '333', '321', row)
 
         self.assertTrue(result)
-


### PR DESCRIPTION
`get_employee` method to support custom fields

from https://web.archive.org/web/20160611131000/http://www.bamboohr.com/api/documentation/employees.php
> In general, an alias for a custom field will be "customFieldName" if the custom field's name is "Field Name". In the case of duplicate field names, a numeric suffix will be appended: "customFieldName", "customFieldName1", etc. These aliases are stable and can be discovered through the Metadata API.