### PR TITLE
Time off request API methods

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -627,15 +627,14 @@ class PyBambooHR(object):
         return r.json()
         # return utils.transform_whos_out(r.content)
 
-    def get_time_off_requests(self, start_date=None, end_date=None, status=None, type=None, employee_id=None):
+    # must set start + end or response = 400 Bad Request
+    def get_time_off_requests(self, start_date='0000-01-01', end_date='9999-01-01', status=None, type=None, employee_id=None):
         start_date = utils.resolve_date_argument(start_date)
         end_date = utils.resolve_date_argument(end_date)
 
         params = {}
-        if start_date:
-            params['start'] = start_date
-        if end_date:
-            params['end'] = end_date
+        params['start'] = start_date
+        params['end'] = end_date
         if status:
             params['status'] = status
         if type:
@@ -645,7 +644,6 @@ class PyBambooHR(object):
 
         r = self._query('time_off/requests', params, raw=True)
         return r.json()
-        # return utils.transform_time_off(r.content)
 
     def create_time_off_request(self, employee_id):
         url = self.base_url + 'employees/{0}/time_off/request/'.format(employee_id)

--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -647,6 +647,24 @@ class PyBambooHR(object):
         return r.json()
         # return utils.transform_time_off(r.content)
 
+    def create_time_off_request(self, employee_id):
+        url = self.base_url + 'employees/{0}/time_off/request/'.format(employee_id)
+        r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''))
+        r.raise_for_status()
+        return True # return new request data if poss
+
+    def update_time_off_request(self, employee_id):
+        url = self.base_url + 'employees/{0}/time_off/request/'.format(employee_id)
+        r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''))
+        r.raise_for_status()
+        return True
+
+    def update_time_off_request_status(self, request_id):
+        url = self.base_url + '/time_off/requests/{0}/status/'.format(request_id)
+        r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''))
+        r.raise_for_status()
+        return True
+
     def get_meta_fields(self):
         """
         API method for returning a list of fields info.

--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -673,7 +673,61 @@ class PyBambooHR(object):
         r = self._query('time_off/requests', params, raw=True)
         return r.json()
 
+    def get_time_off_policies(self):
+        """
+        Api method for returning list of time off policies for a subdomain
+        https://www.bamboohr.com/api/documentation/time_off.php#getTimeOffPolicies
+        Success Response: 200
+        @return: List containing time off policies
+        """
+        url = 'meta/time_off/policies/'
+        r = self._query(url, {})
+        return r
+
+    def get_time_off_types(self):
+        """
+        Api method for returning list of time off types for a subdomain
+        https://www.bamboohr.com/api/documentation/time_off.php#getTimeOffTypes
+        Success Response: 200
+        @return: List containing time off types
+        """
+        url = 'meta/time_off/types/'
+        r = self._query(url, {})
+        return r
+
     def create_time_off_request(self, data, raw=False):
+        """
+        API method for creating a new time off request
+        https://www.bamboohr.com/api/documentation/time_off.php#addRequest
+        Success Response: 201
+        @return: A dictionary containing the created time off request
+        """
+        data['status'] = 'requested'
+        return self.update_time_off_request(data, raw)
+
+    def update_time_off_request(self, data, raw=False):
+        """
+        API method for creating or updating a new time off request
+        https://www.bamboohr.com/api/documentation/time_off.php#addRequest
+        @param data = {
+            'status': 'requested',
+            'employee_id': '113',
+            'start': '2040-02-01',
+            'end': '2040-02-02',
+            'timeOffTypeId': '78',
+            'amount': '2',
+            'dates': [
+                { 'ymd': '2040-02-01', 'amount': '1' },
+                { 'ymd': '2040-02-02', 'amount': '1' }
+            ],
+            'notes': [
+                { 'type': 'employee', 'text': 'Going overseas with family' },
+                { 'type': 'manager', 'text': 'Enjoy!' }
+            ]
+        }
+        Success Response: 201
+        @return: A dictionary containing the created/updated time off request
+        """
         url = self.base_url + 'employees/{0}/time_off/request/'.format(data.get('employee_id'))
         xml = self._format_time_off_xml(data)
         r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''), data=xml)
@@ -683,20 +737,18 @@ class PyBambooHR(object):
         else:
             return r.json()
 
-    def get_time_off_policies(self):
-        url = 'meta/time_off/policies/'
-        r = self._query(url, {})
-        return r
-
-    def update_time_off_request(self, employee_id):
-        url = self.base_url + 'employees/{0}/time_off/request/'.format(employee_id)
-        r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''))
-        r.raise_for_status()
-        return True
-
-    def update_time_off_request_status(self, request_id):
-        url = self.base_url + '/time_off/requests/{0}/status/'.format(request_id)
-        r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''))
+    def update_time_off_request_status(self, request_id, data, raw=False):
+        """
+        https://www.bamboohr.com/api/documentation/time_off.php#changeRequest
+        Success Response: 200
+        @param data = d = {
+            'status': 'denied',
+            'note': 'have fun!'
+        }
+        @return: Boolean of request success (Status Code == 200).
+        """
+        url = self.base_url + 'time_off/requests/{0}/status/'.format(request_id)
+        r = requests.put(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''), json=data)
         r.raise_for_status()
         return True
 

--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -181,7 +181,6 @@ class PyBambooHR(object):
             "commisionDate": ("date", ""),
             "commissionAmount": ("currency", ""),
             "commissionComment": ("text", ""),
-            "commissionComment": ("text", ""),
             "benefitClassDate": ("date", ""),
             "benefitClassClass": ("list", ""),
             "benefitClassChangeReason": ("list", ""),
@@ -249,6 +248,7 @@ class PyBambooHR(object):
         """
         Utility method for turning dictionary of time_off request data into valid xml.
         https://www.bamboohr.com/api/documentation/time_off.php#addRequest
+        @param request_data: Dictionary containing incoming data for time off request
         """
         fields = ['status', 'start', 'end', 'timeOffTypeId', 'amount']
         xml = ''

--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -262,14 +262,14 @@ class PyBambooHR(object):
             for n in request_data['notes']:
                 f = n.get('type', 'employee')
                 t = n.get('text', '')
-                notes += '\n\t\t<note from="{0}">{1}</note>\n'.format(f, t)
-            xml += '\n\t<notes>{0}\t</notes>'.format(notes)
+                notes += '\n\t\t<note from="{0}">{1}</note>'.format(f, t)
+            xml += '\n\t<notes>{0}\n\t</notes>'.format(notes)
 
         if request_data.get('dates') and len(request_data.get('dates')) > 0:
             dates = ''
             for d in request_data['dates']:
-                dates += '\n\t\t<date ymd="{0}" amount="{1}" />\n'.format(d['ymd'], d['amount'])
-            xml += '\n\t<dates>{0}\t</dates>'.format(dates)
+                dates += '\n\t\t<date ymd="{0}" amount="{1}" />'.format(d['ymd'], d['amount'])
+            xml += '\n\t<dates>{0}\n\t</dates>'.format(dates)
 
         return '<request>{0}\n</request>'.format(xml)
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,37 @@ bamboo = PyBambooHR(subdomain='yoursub', api_key='yourapikeyhere', only_current=
 
 ```
 BambooHR has effective dates for when promotions are scheduled to happen or when new hires are going to join the organization. In order to see these events before they happen using the BambooHR API set `only_current` to `False`. As a note, this only works for pulling reports and getting employee information. This does not work on getting the employee directory.
+
+Handle time off requests:
+- create a time off request
+```py
+from PyBambooHR import PyBambooHR
+
+bamboo = PyBambooHR(subdomain='yoursub', api_key='yourapikeyhere')
+data = {
+    'status': 'requested',
+    'employee_id': '113',
+    'start': '2040-02-01',
+    'end': '2040-02-02',
+    'timeOffTypeId': '78', # check your companies valid timeOffTypeId values using  bamboo.get_time_off_policies or bamboo.get_time_off_types
+    'amount': '2',
+    'dates': [
+        { 'ymd': '2040-02-01', 'amount': '1' },
+        { 'ymd': '2040-02-02', 'amount': '1' }
+    ],
+    'notes': [
+        { 'type': 'employee', 'text': 'Going overseas with family' },
+        { 'type': 'manager', 'text': 'Enjoy!' }
+    ]
+}
+time_off_request = bamboo.create_time_off_request(data)
+```
+- update a requests status
+```py
+data = {
+    'status': 'declined',
+    'note': 'have fun!'
+}
+request_id = 222
+bamboo.update_time_off_request_status(request_id, data)
+```


### PR DESCRIPTION
I plan to use these API's in the future, thanks for the project so far 👍 

**Add** API methods for:
- Create / Update time off request
- Update time off request status
- Get company time off policies
- Get company time off types

**Fix**:
- Get time off requests: Must include `start `+ `end` params in get request

**Add** utility method for:
- Turning dictionary to xml for Create/Update time off request