### PR TITLE
Transform tabular JSON tabular data to dict

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -575,7 +575,7 @@ class PyBambooHR(object):
         r = requests.get(url, timeout=self.timeout, headers=self.headers, auth=(self.api_key, ''))
         r.raise_for_status()
 
-        return utils.transform_tabular_data(r.content)
+        return utils.transform_json_tabular_data(r.json())
 
     def get_employee_changed_table(self, table_name='jobInfo', since=None):
         """

--- a/PyBambooHR/utils.py
+++ b/PyBambooHR/utils.py
@@ -141,7 +141,6 @@ def transform_json_tabular_data(json_input):
 
     for user in json_input:
         for row in user:
-            print(row)
             try:
                 eid = row.pop('employeeId')
             except KeyError:

--- a/PyBambooHR/utils.py
+++ b/PyBambooHR/utils.py
@@ -113,6 +113,45 @@ def transform_tabular_data(xml_input):
         by_employee_id.setdefault(eid, []).append(fields)
     return by_employee_id
 
+def transform_json_tabular_data(json_input):
+    """
+    Converts table data (json) from BambooHR into a dictionary with employee
+    id as key and a list of dictionaries.
+    Each field is a dict with the id as the key and inner text as the value
+    e.g.
+        [
+            [
+                {'id': 321, 'employeeId': 123, 'customFieldA': '123 Value A',
+                 'customFieldC': ''}
+            ],
+            [
+                {'id': 999, 'employeeId': 321, 'customFieldA': '321 Value A'}
+            ]
+        ]
+    becomes
+        {'123': [{
+                 'customFieldA': '123 Value A',
+                 'customFieldB': '123 Value B',
+                 'row_id': '321'}],
+         '321': [{
+                 'customFieldA': '321 Value A',
+                 'row_id': '999'}]}
+    """
+    by_employee_id = {}
+
+    for user in json_input:
+        for row in user:
+            print(row)
+            try:
+                eid = row.pop('employeeId')
+            except KeyError:
+                continue
+            row['row_id'] = str(row.pop('id'))
+
+            by_employee_id.setdefault(str(eid), []).append(row)
+
+    return by_employee_id
+
 def transform_table_data(xml_input):
     """
     Converts table data (xml) from BambooHR into a dictionary or list

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -239,18 +239,21 @@ class test_employees(unittest.TestCase):
 
     @httpretty.activate
     def test_get_tabular_data(self):
-        xml = """<?xml version="1.0"?>
-                 <table>
-                     <row id="321" employeeId="123">
-                         <field id="customTypeA">Value A</field>
-                         <field id="customTypeB">Value B</field>
-                         <field id="customTypeC">Value C</field>
-                     </row>
-                 </table>"""
+        json_data = """[
+            [
+                {
+                    "id": 321,
+                    "employeeId": 123,
+                    "customTypeA": "Value A",
+                    "customTypeB": "Value B",
+                    "customTypeC": "Value C"
+                }
+            ]
+        ]"""
         httpretty.register_uri(httpretty.GET,
                                "https://api.bamboohr.com/api/gateway.php/test/v1/employees/123/tables/customTable",
-                               body=xml,
-                               content_type="application/xml")
+                               body=json_data,
+                               content_type="application/json")
         table = self.bamboo.get_tabular_data('customTable', 123)
         d = {'123': [{'customTypeA': 'Value A',
                       'customTypeB': 'Value B',
@@ -262,23 +265,28 @@ class test_employees(unittest.TestCase):
 
     @httpretty.activate
     def test_get_tabular_data_all_employees(self):
-        xml = """<?xml version="1.0"?>
-                 <table>
-                     <row id="321" employeeId="123">
-                         <field id="customTypeA">Value A</field>
-                         <field id="customTypeB">Value B</field>
-                         <field id="customTypeC">Value C</field>
-                     </row>
-                     <row id="322" employeeId="333">
-                         <field id="customTypeA">333 Value A</field>
-                         <field id="customTypeB">333 Value B</field>
-                         <field id="customTypeC">333 Value C</field>
-                     </row>
-                 </table>"""
+        json_data = """[
+            [
+                {
+                    "id": 321,
+                    "employeeId": 123,
+                    "customTypeA": "Value A",
+                    "customTypeB": "Value B",
+                    "customTypeC": "Value C"
+                },
+                {
+                    "id": 322,
+                    "employeeId": 333,
+                    "customTypeA": "333 Value A",
+                    "customTypeB": "333 Value B",
+                    "customTypeC": "333 Value C"
+                }
+            ]
+        ]"""
         httpretty.register_uri(httpretty.GET,
                                "https://api.bamboohr.com/api/gateway.php/test/v1/employees/all/tables/customTable",
-                               body=xml,
-                               content_type="application/xml")
+                               body=json_data,
+                               content_type="application/json")
         table = self.bamboo.get_tabular_data('customTable')
         d = {'123': [{'customTypeA': 'Value A',
                       'customTypeB': 'Value B',
@@ -288,7 +296,6 @@ class test_employees(unittest.TestCase):
                       'customTypeB': '333 Value B',
                       'customTypeC': '333 Value C',
                       'row_id': '322'}]}
-
         self.assertIsNotNone(table)
         self.assertEqual(d, table)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -140,3 +140,70 @@ class test_misc(unittest.TestCase):
                           'row_id': '999'}]}
 
         self.assertEqual(table, utils.transform_tabular_data(xml))
+
+    def test_transform_json_tabular_data(self):
+        json_data = [
+            [
+                {
+                    "id": 321,
+                    "employeeId": 123,
+                    "customFieldA": "123 Value A",
+                    "customFieldB": "123 Value B",
+                },
+                {
+                    "id": 999,
+                    "employeeId": 321,
+                    "customFieldA": "321 & Value A",
+                }
+            ]
+        ]
+        table = {'123': [{
+                         'customFieldA': '123 Value A',
+                         'customFieldB': '123 Value B',
+                         'row_id': '321'}],
+                 '321': [{
+                         'customFieldA': '321 & Value A',
+                         'row_id': '999'}]}
+        self.assertEqual(table, utils.transform_json_tabular_data(json_data))
+
+    def test_transform_json_tabular_data_single_row(self):
+        json_data = [
+            [
+                {
+                    "id": 321,
+                    "employeeId": 123,
+                    "customFieldA": "123 Value A",
+                }
+            ]
+        ]
+        table = {'123': [{'customFieldA': '123 Value A', 'row_id': '321'}]}
+        self.assertEqual(table, utils.transform_json_tabular_data(json_data))
+
+    def test_transform_json_tabular_data_empty_table(self):
+        json_data = [[{}]]
+        table = {}
+        self.assertEqual(table, utils.transform_json_tabular_data(json_data))
+
+    def test_transform_json_tabular_data_empty_field(self):
+        json_data = [
+            [
+                {
+                    "id": 321,
+                    "employeeId": 123,
+                    "customFieldA": "123 Value A",
+                    "customFieldC": None,
+                },
+                {
+                    "id": 999,
+                    "employeeId": 321,
+                    "customFieldB": "321 Value B",
+                }
+            ]
+        ]
+        table = {'123': [{'customFieldA': '123 Value A',
+                          'customFieldC': None,
+                          'row_id': '321'}],
+                 '321': [{'customFieldB': '321 Value B',
+                          'row_id': '999'}]}
+
+        self.assertEqual(table, utils.transform_json_tabular_data(json_data))


### PR DESCRIPTION
Currently (before this change), PyBambooHR.get_tabular_data fetches data as JSON but it calls utils.transform_tabular_data which excepts XML, and thus calling PyBambooHR.get_tabular_data fails.

I implemented a new utils.transform_json_tabular_data function to transform the JSON data to dict and changed PyBambooHR.get_tabular_data to call that instead. The result should be identical to that of the old implementation if the old implementation worked.

Connects #62.

This is an alternative solution to the same problem that #66 fixes, and #64 also includes a similar fix. The main difference is that this solution uses JSON instead XML. However, if #64 or #66 is merged, this PR can be closed.